### PR TITLE
Overview search, per-monitor workspace preview, and keybinding fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  menu-index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      # MenuIndex.js is plain JS with no dependencies, so there is nothing to
+      # install. The fixtures live in tests/, so Omarchy is not needed either.
+      - run: node --test

--- a/AppSearch.qml
+++ b/AppSearch.qml
@@ -29,7 +29,15 @@ Singleton {
         printErrors: false
         onLoaded: root.loadHides(text())
         onFileChanged: reload()
-        onLoadFailed: root.loadHides("")
+        // Not fatal: without the list, application results simply include the
+        // entries Omarchy's own launcher hides. Worth saying so out loud rather
+        // than silently diverging from the Super+Space menu.
+        onLoadFailed: {
+            console.warn("hancore.overview-workspaces: no launcher.hides at "
+                + `${root.omarchyPath}/default/omarchy/launcher.hides`
+                + " -- hidden applications will show in search results");
+            root.loadHides("");
+        }
     }
 
     function loadHides(rawText) {

--- a/AppSearch.qml
+++ b/AppSearch.qml
@@ -2,12 +2,66 @@ pragma Singleton
 import QtQuick
 import Quickshell
 
+// Busqueda de aplicaciones para el modo search del overview.
+//
+// Antes esto era un stub que devolvia [] y hacia que la seccion "Applications"
+// nunca apareciera. Ahora consulta DesktopEntries, el mismo origen que usa
+// services/AppLibrary.qml de Omarchy, para que los resultados coincidan con los
+// del menu de Super+Space.
 QtObject {
+    id: root
+
     function iconSource(iconName, fallback) {
         const path = Quickshell.iconPath(iconName || fallback || "application-x-executable", true)
         return path ? (path.startsWith("/") ? `file://${path}` : path) : ""
     }
+
     function guessIcon(name) { return name || "application-x-executable" }
-    function fuzzyQuery(query) { return [] }
-    function launchApp(app) { return false }
+
+    function entryHaystack(entry) {
+        return [
+            entry?.name || "",
+            entry?.genericName || "",
+            entry?.comment || "",
+            entry?.id || ""
+        ].join(" ").toLowerCase();
+    }
+
+    // Ordena por que tan "al principio" cae el match: primero los que empiezan
+    // con la query, despues los que la tienen en el nombre, y al final los que
+    // solo matchean por comment/id. Empates alfabeticos.
+    function fuzzyQuery(query) {
+        const needle = String(query || "").toLowerCase().trim();
+        if (needle.length === 0)
+            return [];
+
+        const values = DesktopEntries.applications.values || [];
+        const scored = [];
+        for (let i = 0; i < values.length; ++i) {
+            const entry = values[i];
+            if (!entry || entry.noDisplay)
+                continue;
+            const position = root.entryHaystack(entry).indexOf(needle);
+            if (position < 0)
+                continue;
+            const name = String(entry.name || "");
+            const nameIndex = name.toLowerCase().indexOf(needle);
+            const score = nameIndex === 0 ? 0 : (nameIndex > 0 ? 1 : 2 + position);
+            scored.push({ entry: entry, score: score, name: name });
+        }
+
+        scored.sort((a, b) => (a.score - b.score) || a.name.localeCompare(b.name));
+        return scored.map(item => item.entry);
+    }
+
+    // uwsm-app deja la app fuera de wayland-wm@.service, y gtk-launch resuelve
+    // ids con espacios o que UWSM rechaza. El sufijo .desktop es obligatorio o
+    // ids como org.telegram.desktop no resuelven. Mismo criterio que AppLibrary.
+    function launchApp(app) {
+        const id = String(app?.id || "");
+        if (id.length === 0)
+            return false;
+        Quickshell.execDetached(["uwsm-app", "--", "gtk-launch", `${id}.desktop`]);
+        return true;
+    }
 }

--- a/AppSearch.qml
+++ b/AppSearch.qml
@@ -1,14 +1,47 @@
 pragma Singleton
 import QtQuick
 import Quickshell
+import Quickshell.Io
 
 // Application lookup for the overview's search mode.
 //
 // This used to be a stub returning [], which meant the "Applications" section
 // could never appear. It now queries DesktopEntries, the same source Omarchy's
-// own services/AppLibrary.qml uses, so results agree with the Super+Space menu.
-QtObject {
+// own services/AppLibrary.qml uses, and applies the same launcher.hides filter,
+// so results agree with the Super+Space menu.
+Singleton {
     id: root
+
+    readonly property string omarchyPath: Quickshell.env("OMARCHY_PATH") || "/usr/share/omarchy"
+
+    // NoDisplay alone is not enough: Omarchy hides a further list of desktop ids
+    // that ship without it (btop, cmake-gui, avahi-discover and 35 others), so
+    // filtering on NoDisplay only would surface entries its own launcher hides.
+    property var hiddenIds: ({})
+
+    function normalizeDesktopId(value) {
+        return String(value || "").trim().replace(/\.desktop$/, "");
+    }
+
+    FileView {
+        path: `${root.omarchyPath}/default/omarchy/launcher.hides`
+        watchChanges: true
+        printErrors: false
+        onLoaded: root.loadHides(text())
+        onFileChanged: reload()
+        onLoadFailed: root.loadHides("")
+    }
+
+    function loadHides(rawText) {
+        const next = ({});
+        const lines = String(rawText || "").split(/\n/);
+        for (let i = 0; i < lines.length; ++i) {
+            const id = root.normalizeDesktopId(lines[i]);
+            if (id.length > 0)
+                next[id] = true;
+        }
+        root.hiddenIds = next;
+    }
 
     function iconSource(iconName, fallback) {
         const path = Quickshell.iconPath(iconName || fallback || "application-x-executable", true)
@@ -39,6 +72,8 @@ QtObject {
         for (let i = 0; i < values.length; ++i) {
             const entry = values[i];
             if (!entry || entry.noDisplay)
+                continue;
+            if (root.hiddenIds[root.normalizeDesktopId(entry.id)])
                 continue;
             const position = root.entryHaystack(entry).indexOf(needle);
             if (position < 0)

--- a/AppSearch.qml
+++ b/AppSearch.qml
@@ -2,12 +2,11 @@ pragma Singleton
 import QtQuick
 import Quickshell
 
-// Busqueda de aplicaciones para el modo search del overview.
+// Application lookup for the overview's search mode.
 //
-// Antes esto era un stub que devolvia [] y hacia que la seccion "Applications"
-// nunca apareciera. Ahora consulta DesktopEntries, el mismo origen que usa
-// services/AppLibrary.qml de Omarchy, para que los resultados coincidan con los
-// del menu de Super+Space.
+// This used to be a stub returning [], which meant the "Applications" section
+// could never appear. It now queries DesktopEntries, the same source Omarchy's
+// own services/AppLibrary.qml uses, so results agree with the Super+Space menu.
 QtObject {
     id: root
 
@@ -27,9 +26,9 @@ QtObject {
         ].join(" ").toLowerCase();
     }
 
-    // Ordena por que tan "al principio" cae el match: primero los que empiezan
-    // con la query, despues los que la tienen en el nombre, y al final los que
-    // solo matchean por comment/id. Empates alfabeticos.
+    // Ranked by how early the match lands: names starting with the query first,
+    // then names containing it, then entries matching only on comment or id.
+    // Ties break alphabetically.
     function fuzzyQuery(query) {
         const needle = String(query || "").toLowerCase().trim();
         if (needle.length === 0)
@@ -54,9 +53,9 @@ QtObject {
         return scored.map(item => item.entry);
     }
 
-    // uwsm-app deja la app fuera de wayland-wm@.service, y gtk-launch resuelve
-    // ids con espacios o que UWSM rechaza. El sufijo .desktop es obligatorio o
-    // ids como org.telegram.desktop no resuelven. Mismo criterio que AppLibrary.
+    // uwsm-app keeps the app out of wayland-wm@.service, and gtk-launch resolves
+    // ids with spaces or ones UWSM rejects. The .desktop suffix is required or
+    // ids like org.telegram.desktop will not resolve. Same approach as AppLibrary.
     function launchApp(app) {
         const id = String(app?.id || "");
         if (id.length === 0)

--- a/Config.qml
+++ b/Config.qml
@@ -8,10 +8,6 @@ QtObject {
             property int columns: 5
             property bool centerIcons: true
             property bool orderRightLeft: false
-            // Cada overlay muestra solo los workspaces de SU monitor. Con false
-            // las dos pantallas dibujan la grilla completa y ves los workspaces
-            // del otro monitor repetidos en ambas.
-            property bool perMonitor: true
         }
         readonly property QtObject background: QtObject { property string wallpaperPath: ""; property string thumbnailPath: "" }
         readonly property QtObject hacks: QtObject { property int arbitraryRaceConditionDelay: 50 }

--- a/Config.qml
+++ b/Config.qml
@@ -8,6 +8,10 @@ QtObject {
             property int columns: 5
             property bool centerIcons: true
             property bool orderRightLeft: false
+            // Cada overlay muestra solo los workspaces de SU monitor. Con false
+            // las dos pantallas dibujan la grilla completa y ves los workspaces
+            // del otro monitor repetidos en ambas.
+            property bool perMonitor: true
         }
         readonly property QtObject background: QtObject { property string wallpaperPath: ""; property string thumbnailPath: "" }
         readonly property QtObject hacks: QtObject { property int arbitraryRaceConditionDelay: 50 }

--- a/GlobalStates.qml
+++ b/GlobalStates.qml
@@ -23,6 +23,10 @@ Singleton {
     // The plugin's optimized visual ordering is the default. The persisted
     // setting can still switch to the native Omarchy order explicitly.
     property string overviewSortMode: "legacy"
+    // When true, h/j/k/l keep navigating workspaces and search opens on "/" --
+    // the vim idiom. When false any printable character opens search, which is
+    // quicker but takes those keys away from navigation.
+    property bool overviewVimKeys: true
     // Each overlay draws only its own monitor's workspaces. Persisted to the bar
     // widget entry in shell.json, the same way overviewSortMode is.
     property bool overviewPerMonitor: true

--- a/GlobalStates.qml
+++ b/GlobalStates.qml
@@ -23,6 +23,9 @@ Singleton {
     // The plugin's optimized visual ordering is the default. The persisted
     // setting can still switch to the native Omarchy order explicitly.
     property string overviewSortMode: "legacy"
+    // Cada overlay dibuja solo los workspaces de SU monitor. Se persiste en la
+    // entrada del bar widget en shell.json, igual que overviewSortMode.
+    property bool overviewPerMonitor: true
     property int overviewFocusedWorkspaceId: -1
     property var overviewWorkspaceMru: []
     property int overviewDraggingFromWorkspace: -1

--- a/GlobalStates.qml
+++ b/GlobalStates.qml
@@ -23,8 +23,8 @@ Singleton {
     // The plugin's optimized visual ordering is the default. The persisted
     // setting can still switch to the native Omarchy order explicitly.
     property string overviewSortMode: "legacy"
-    // Cada overlay dibuja solo los workspaces de SU monitor. Se persiste en la
-    // entrada del bar widget en shell.json, igual que overviewSortMode.
+    // Each overlay draws only its own monitor's workspaces. Persisted to the bar
+    // widget entry in shell.json, the same way overviewSortMode is.
     property bool overviewPerMonitor: true
     property int overviewFocusedWorkspaceId: -1
     property var overviewWorkspaceMru: []

--- a/KeybindingService.qml
+++ b/KeybindingService.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import Quickshell
+import Quickshell.Hyprland
 
 Item {
     id: root
@@ -127,6 +128,25 @@ Item {
     Connections {
         target: root.shell
         function onShellConfigChanged() {
+            Qt.callLater(root.applyBindings);
+        }
+    }
+
+    // These bindings live only in Hyprland's runtime, so anything that makes it
+    // re-read its config wipes them: a theme change, `omarchy refresh`, editing a
+    // .lua file, or a monitor hotplug (hypr-monitor-arrange reloads to re-detect
+    // displays). Until now nothing re-registered them, so Super fell back to
+    // Omarchy's own menu until the shell was restarted by hand.
+    Connections {
+        target: Hyprland
+
+        function onRawEvent(event) {
+            if (event?.name !== "configreloaded")
+                return;
+            // The reload already dropped the bindings, but appliedMode still says
+            // they are installed and applyBindings() would return early. Clearing
+            // it is what makes the re-registration actually run.
+            root.appliedMode = "";
             Qt.callLater(root.applyBindings);
         }
     }

--- a/MenuIndex.js
+++ b/MenuIndex.js
@@ -91,9 +91,18 @@ function mergeMenuSources(defaultItems, userItems) {
         var list = sources[s];
         for (var i = 0; i < list.length; i++) {
             var entry = list[i];
+            if (!entry || !entry.id)
+                continue;
             if (!items[entry.id])
                 order.push(entry.id);
-            items[entry.id] = entry;
+            var prior = items[entry.id] || {};
+            var merged = {};
+            for (var a in prior)
+                merged[a] = prior[a];
+            for (var b in entry)
+                merged[b] = entry[b];
+            merged.id = entry.id;
+            items[entry.id] = merged;
         }
     }
     for (var k = 0; k < order.length; k++)

--- a/MenuIndex.js
+++ b/MenuIndex.js
@@ -1,18 +1,18 @@
-// Indice buscable del command menu de Omarchy (el de Super+Space).
+// Searchable index of Omarchy's command menu (the Super+Space one).
 //
-// Implementacion propia y autocontenida. Deliberadamente NO importa
-// /usr/share/omarchy/shell/plugins/menu/MenuModel.js: los imports de JS en QML
-// son estaticos, Omarchy resuelve su prefijo por $OMARCHY_PATH y en NixOS eso no
-// es /usr/share/omarchy, asi que una ruta fija romperia la carga del plugin
-// entero en vez de degradar la busqueda.
+// Self-contained implementation. It deliberately does NOT import
+// /usr/share/omarchy/shell/plugins/menu/MenuModel.js: QML resolves JS imports
+// statically, Omarchy resolves its prefix from $OMARCHY_PATH, and on NixOS that
+// is not /usr/share/omarchy -- so a fixed path would fail to load the entire
+// plugin instead of degrading the search.
 //
-// Solo cubre lo necesario para buscar acciones ejecutables. Queda afuera a
-// proposito todo lo que hace falta para *navegar* el menu: providers, filas de
-// apps, rutas por alias y el marcador `checked`.
+// It covers only what searching executable actions needs. Everything required to
+// *navigate* the menu is intentionally left out: providers, app rows, alias
+// routes and the `checked` marker.
 
 .pragma library
 
-// ── Parseo del JSONC ───────────────────────────────────────────────────────
+// ── JSONC parsing ──────────────────────────────────────────────────────────
 
 function stripJsonc(raw) {
     return String(raw || "")
@@ -28,9 +28,9 @@ function normalizeAliases(value) {
     return [];
 }
 
-// Los ids con puntos definen la jerarquia: trigger.share.file cuelga de
-// trigger.share. El kind se infiere: action -> action, target -> link, resto
-// submenu.
+// Dotted ids define the hierarchy: trigger.share.file belongs under
+// trigger.share. Kind is inferred: action -> action, target -> link, otherwise
+// a submenu.
 function normalizeItem(id, raw) {
     var value = raw || {};
     var parent = value.parent;
@@ -79,9 +79,9 @@ function parseMenuJsonc(raw) {
     return out;
 }
 
-// El jsonc del usuario pisa al default por id. Devuelve objetos nuevos en vez de
-// escribir sobre los que recibe: viven en propiedades `var` de QML y el motor a
-// veces descarta una escritura in-place.
+// The user's jsonc overrides the default by id. Returns fresh objects rather
+// than writing into the ones it is handed: those live in QML `var` properties,
+// where the engine occasionally drops an in-place write.
 function mergeMenuSources(defaultItems, userItems) {
     var items = {};
     var order = [];
@@ -106,7 +106,7 @@ function item(items, id) {
     return items && items[id] ? items[id] : null;
 }
 
-// ── Jerarquia ──────────────────────────────────────────────────────────────
+// ── Hierarchy ──────────────────────────────────────────────────────────────
 
 function depthFor(items, id) {
     var depth = 0;
@@ -169,9 +169,9 @@ function termInSearchWords(term, text) {
     return false;
 }
 
-// Cada termino tiene que aparecer en el nombre o como palabra entera de la
-// descripcion. Una subcadena suelta de la descripcion no alcanza: "in" no
-// deberia traer todo lo que diga "install".
+// Every term must appear in the name, or as a whole word of the description. A
+// bare substring of the description is not enough: "in" should not pull in
+// everything that says "install".
 function matchesQuery(entry, query) {
     if (!entry || entry.id === "root")
         return false;
@@ -192,9 +192,9 @@ function matchesQuery(entry, query) {
     return true;
 }
 
-// Menor es mejor. El label exacto gana, despues prefijo, despues subcadena, y al
-// final los que solo matchean por descripcion. Se desempata por profundidad y
-// por orden de declaracion, para que el resultado sea estable.
+// Lower is better. An exact label wins, then a prefix, then a substring, and
+// last the entries matching on description only. Ties break by depth and then
+// declaration order, so the ranking is stable.
 function searchScore(items, entry, query) {
     var needle = String(query || "").toLowerCase().trim();
     var label = String(entry.label || "").toLowerCase();
@@ -218,16 +218,16 @@ function searchScore(items, entry, query) {
 
 // ── Guards ─────────────────────────────────────────────────────────────────
 
-// Un unico script bash que resuelve todos los `when:` de una pasada e imprime
-// "<id>:w:<0|1>" por linea. Se hace en batch porque son ~144 condiciones y un
-// proceso por cada una tardaria muchisimo mas.
+// A single bash script that resolves every `when:` in one pass, printing
+// "<id>:w:<0|1>" per line. Batching matters: there are ~144 conditions, and one
+// process each would take far longer.
 //
-// A diferencia de Omarchy no se emite un prelude que cachee pacman: sus helpers
-// (omarchy-pkg-present, omarchy-cmd-present) existen como binarios reales en
-// $OMARCHY_PATH/bin, asi que las expresiones corren igual. Medido en esta
-// maquina: 2.87 s contra 2.22 s del batch optimizado, con resultados identicos
-// en los 144 guards. La diferencia no se nota porque esto corre en background y
-// el resultado queda cacheado.
+// Unlike Omarchy, no pacman-caching prelude is emitted: the helpers it relies on
+// (omarchy-pkg-present, omarchy-cmd-present) exist as real binaries in
+// $OMARCHY_PATH/bin, so the expressions run either way. Measured here at 2.87s
+// against 2.22s for the optimised batch, with identical results across all 144
+// guards. The difference goes unnoticed because this runs in the background and
+// the answers are cached.
 function guardScript(items) {
     var script = "";
     var ids = Object.keys(items || {});

--- a/MenuIndex.js
+++ b/MenuIndex.js
@@ -10,7 +10,6 @@
 // *navigate* the menu is intentionally left out: providers, app rows, alias
 // routes and the `checked` marker.
 
-.pragma library
 
 // ── JSONC parsing ──────────────────────────────────────────────────────────
 
@@ -268,4 +267,55 @@ function guardScript(items) {
             + shellQuote(ids[i] + ":w:0") + "; fi\n";
     }
     return script;
+}
+
+// Reads back what guardScript() emitted: one "<id>:<tag>:<0|1>" line per guard.
+// Split from the right, because an id may contain dots and the tag never does.
+// Only the "w" (when) tag is of interest; "c" (checked) drives the menu's tick.
+function parseGuardReply(text) {
+    var results = {};
+    var lines = String(text || "").split("\n");
+
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i].trim();
+        if (!line)
+            continue;
+        var colon = line.lastIndexOf(":");
+        if (colon < 0)
+            continue;
+        var value = line.substring(colon + 1) === "1";
+        var rest = line.substring(0, colon);
+        var tagAt = rest.lastIndexOf(":");
+        if (tagAt < 0)
+            continue;
+        if (rest.substring(tagAt + 1) === "w")
+            results[rest.substring(0, tagAt)] = value;
+    }
+    return results;
+}
+
+// Importable from QML as a plain JS library and from Node for the test suite.
+// Same shape Omarchy's own MenuModel.js uses; `module` is undefined under QML,
+// so this block is simply skipped there.
+if (typeof module !== "undefined") {
+    module.exports = {
+        stripJsonc: stripJsonc,
+        normalizeAliases: normalizeAliases,
+        normalizeItem: normalizeItem,
+        parseMenuJsonc: parseMenuJsonc,
+        mergeMenuSources: mergeMenuSources,
+        item: item,
+        depthFor: depthFor,
+        pathFor: pathFor,
+        parentPathFor: parentPathFor,
+        searchableToken: searchableToken,
+        leafIdFor: leafIdFor,
+        nameSearchText: nameSearchText,
+        termInSearchWords: termInSearchWords,
+        matchesQuery: matchesQuery,
+        searchScore: searchScore,
+        shellQuote: shellQuote,
+        guardScript: guardScript,
+        parseGuardReply: parseGuardReply
+    };
 }

--- a/MenuIndex.js
+++ b/MenuIndex.js
@@ -238,8 +238,11 @@ function searchScore(items, entry, query) {
 // guards. The difference goes unnoticed because this runs in the background and
 // the answers are cached.
 // Wraps a value so bash sees it literally, however the menu spells its ids.
+// The explicit null check keeps this file on the same ES5 subset as the rest of
+// it -- no nullish coalescing, matching its 46 `var` declarations.
 function shellQuote(value) {
-    return "'" + String(value ?? "").replace(/'/g, "'\\''") + "'";
+    var text = (value === null || value === undefined) ? "" : String(value);
+    return "'" + text.replace(/'/g, "'\\''") + "'";
 }
 
 function guardScript(items) {

--- a/MenuIndex.js
+++ b/MenuIndex.js
@@ -237,6 +237,11 @@ function searchScore(items, entry, query) {
 // against 2.22s for the optimised batch, with identical results across all 144
 // guards. The difference goes unnoticed because this runs in the background and
 // the answers are cached.
+// Wraps a value so bash sees it literally, however the menu spells its ids.
+function shellQuote(value) {
+    return "'" + String(value ?? "").replace(/'/g, "'\\''") + "'";
+}
+
 function guardScript(items) {
     var script = "";
     var ids = Object.keys(items || {});
@@ -245,8 +250,19 @@ function guardScript(items) {
         var entry = items[ids[i]];
         if (!entry || !entry.when)
             continue;
-        script += "if { " + entry.when + "; } >/dev/null 2>&1; then echo "
-            + ids[i] + ":w:1; else echo " + ids[i] + ":w:0; fi\n";
+        // The reply is parsed by splitting on the last two colons, so an id
+        // carrying a colon or a newline could not be read back. Skipping it
+        // leaves that row's guard unanswered, which shows the row -- better than
+        // corrupting the reply for every other row in the batch.
+        if (/[\n\r:]/.test(ids[i]))
+            continue;
+        // printf with a quoted payload rather than a bare echo: an id containing
+        // a glob character would otherwise be expanded against the working
+        // directory, emitting one line per matching file and desynchronising the
+        // whole reply.
+        script += "if { " + entry.when + "; } >/dev/null 2>&1; then printf '%s\\n' "
+            + shellQuote(ids[i] + ":w:1") + "; else printf '%s\\n' "
+            + shellQuote(ids[i] + ":w:0") + "; fi\n";
     }
     return script;
 }

--- a/MenuIndex.js
+++ b/MenuIndex.js
@@ -1,0 +1,243 @@
+// Indice buscable del command menu de Omarchy (el de Super+Space).
+//
+// Implementacion propia y autocontenida. Deliberadamente NO importa
+// /usr/share/omarchy/shell/plugins/menu/MenuModel.js: los imports de JS en QML
+// son estaticos, Omarchy resuelve su prefijo por $OMARCHY_PATH y en NixOS eso no
+// es /usr/share/omarchy, asi que una ruta fija romperia la carga del plugin
+// entero en vez de degradar la busqueda.
+//
+// Solo cubre lo necesario para buscar acciones ejecutables. Queda afuera a
+// proposito todo lo que hace falta para *navegar* el menu: providers, filas de
+// apps, rutas por alias y el marcador `checked`.
+
+.pragma library
+
+// ── Parseo del JSONC ───────────────────────────────────────────────────────
+
+function stripJsonc(raw) {
+    return String(raw || "")
+        .replace(/^\s*\/\/[^\n]*(\n|$)/gm, "")
+        .replace(/,(\s*[}\]])/g, "$1");
+}
+
+function normalizeAliases(value) {
+    if (Array.isArray(value))
+        return value.filter(function (v) { return v; });
+    if (typeof value === "string" && value)
+        return [value];
+    return [];
+}
+
+// Los ids con puntos definen la jerarquia: trigger.share.file cuelga de
+// trigger.share. El kind se infiere: action -> action, target -> link, resto
+// submenu.
+function normalizeItem(id, raw) {
+    var value = raw || {};
+    var parent = value.parent;
+    if (parent === undefined)
+        parent = id.indexOf(".") >= 0 ? id.split(".").slice(0, -1).join(".") : "root";
+    if (id === "root")
+        parent = "";
+
+    return {
+        id: id,
+        parent: parent,
+        kind: value.action ? "action" : (value.target ? "link" : "menu"),
+        label: value.label || id,
+        description: value.description || "",
+        action: value.action || "",
+        aliases: normalizeAliases(value.aliases),
+        when: value.when || ""
+    };
+}
+
+function parseMenuJsonc(raw) {
+    var stripped = stripJsonc(raw);
+    if (!stripped.trim())
+        return [];
+
+    var parsed;
+    try {
+        parsed = JSON.parse(stripped);
+    } catch (e) {
+        return [];
+    }
+    if (typeof parsed !== "object" || parsed === null)
+        return [];
+
+    var source = (parsed.items && typeof parsed.items === "object" && !Array.isArray(parsed.items))
+        ? parsed.items
+        : parsed;
+
+    var out = [];
+    for (var id in source) {
+        var entry = source[id];
+        if (!entry || typeof entry !== "object" || Array.isArray(entry))
+            continue;
+        out.push(normalizeItem(id, entry));
+    }
+    return out;
+}
+
+// El jsonc del usuario pisa al default por id. Devuelve objetos nuevos en vez de
+// escribir sobre los que recibe: viven en propiedades `var` de QML y el motor a
+// veces descarta una escritura in-place.
+function mergeMenuSources(defaultItems, userItems) {
+    var items = {};
+    var order = [];
+    var sources = [defaultItems || [], userItems || []];
+
+    for (var s = 0; s < sources.length; s++) {
+        var list = sources[s];
+        for (var i = 0; i < list.length; i++) {
+            var entry = list[i];
+            if (!items[entry.id])
+                order.push(entry.id);
+            items[entry.id] = entry;
+        }
+    }
+    for (var k = 0; k < order.length; k++)
+        items[order[k]].order = k;
+
+    return { items: items, itemOrder: order };
+}
+
+function item(items, id) {
+    return items && items[id] ? items[id] : null;
+}
+
+// ── Jerarquia ──────────────────────────────────────────────────────────────
+
+function depthFor(items, id) {
+    var depth = 0;
+    var current = item(items, id);
+    var guard = 0;
+    while (current && current.parent && current.parent !== "root" && guard < 32) {
+        depth += 1;
+        current = item(items, current.parent);
+        guard += 1;
+    }
+    return depth;
+}
+
+function pathFor(items, id) {
+    var labels = [];
+    var current = item(items, id);
+    var guard = 0;
+    while (current && current.id !== "root" && guard < 32) {
+        labels.unshift(current.label);
+        current = item(items, current.parent);
+        guard += 1;
+    }
+    return labels.join(" › ");
+}
+
+function parentPathFor(items, id) {
+    var entry = item(items, id);
+    if (!entry || !entry.parent || entry.parent === "root")
+        return "";
+    return pathFor(items, entry.parent);
+}
+
+// ── Matching ───────────────────────────────────────────────────────────────
+
+function searchableToken(value) {
+    return String(value || "").replace(/[._-]+/g, " ");
+}
+
+function leafIdFor(id) {
+    var parts = String(id || "").split(".");
+    return parts.length > 0 ? parts[parts.length - 1] : id;
+}
+
+function nameSearchText(entry) {
+    if (!entry)
+        return "";
+    var aliases = [];
+    var values = Array.isArray(entry.aliases) ? entry.aliases : [];
+    for (var i = 0; i < values.length; i++)
+        aliases.push(searchableToken(values[i]));
+    return [entry.label, searchableToken(leafIdFor(entry.id)), aliases.join(" ")].join(" ").toLowerCase();
+}
+
+function termInSearchWords(term, text) {
+    var words = String(text || "").toLowerCase().split(/\s+/);
+    for (var i = 0; i < words.length; i++) {
+        if (words[i] === term)
+            return true;
+    }
+    return false;
+}
+
+// Cada termino tiene que aparecer en el nombre o como palabra entera de la
+// descripcion. Una subcadena suelta de la descripcion no alcanza: "in" no
+// deberia traer todo lo que diga "install".
+function matchesQuery(entry, query) {
+    if (!entry || entry.id === "root")
+        return false;
+
+    var nameText = nameSearchText(entry);
+    var descriptionText = String(entry.description || "").toLowerCase();
+    var terms = String(query || "").toLowerCase().trim().split(/\s+/);
+
+    for (var i = 0; i < terms.length; i++) {
+        if (!terms[i])
+            continue;
+        if (nameText.indexOf(terms[i]) >= 0)
+            continue;
+        if (termInSearchWords(terms[i], descriptionText))
+            continue;
+        return false;
+    }
+    return true;
+}
+
+// Menor es mejor. El label exacto gana, despues prefijo, despues subcadena, y al
+// final los que solo matchean por descripcion. Se desempata por profundidad y
+// por orden de declaracion, para que el resultado sea estable.
+function searchScore(items, entry, query) {
+    var needle = String(query || "").toLowerCase().trim();
+    var label = String(entry.label || "").toLowerCase();
+    var nameText = nameSearchText(entry);
+    var descriptionText = String(entry.description || "").toLowerCase();
+    var score = 80;
+
+    if (label === needle)
+        score = entry.parent === "root" ? 2 : 0;
+    else if (label.indexOf(needle) === 0)
+        score = 10;
+    else if (label.indexOf(needle) >= 0)
+        score = 30;
+    else if (nameText.indexOf(needle) >= 0)
+        score = 40;
+    else if (descriptionText.indexOf(needle) >= 0)
+        score = 60;
+
+    return score * 1000 + depthFor(items, entry.id) * 25 + (entry.order || 0);
+}
+
+// ── Guards ─────────────────────────────────────────────────────────────────
+
+// Un unico script bash que resuelve todos los `when:` de una pasada e imprime
+// "<id>:w:<0|1>" por linea. Se hace en batch porque son ~144 condiciones y un
+// proceso por cada una tardaria muchisimo mas.
+//
+// A diferencia de Omarchy no se emite un prelude que cachee pacman: sus helpers
+// (omarchy-pkg-present, omarchy-cmd-present) existen como binarios reales en
+// $OMARCHY_PATH/bin, asi que las expresiones corren igual. Medido en esta
+// maquina: 2.87 s contra 2.22 s del batch optimizado, con resultados identicos
+// en los 144 guards. La diferencia no se nota porque esto corre en background y
+// el resultado queda cacheado.
+function guardScript(items) {
+    var script = "";
+    var ids = Object.keys(items || {});
+
+    for (var i = 0; i < ids.length; i++) {
+        var entry = items[ids[i]];
+        if (!entry || !entry.when)
+            continue;
+        script += "if { " + entry.when + "; } >/dev/null 2>&1; then echo "
+            + ids[i] + ":w:1; else echo " + ids[i] + ":w:0; fi\n";
+    }
+    return script;
+}

--- a/MenuSearch.qml
+++ b/MenuSearch.qml
@@ -122,6 +122,17 @@ Singleton {
         printErrors: false
         onLoaded: { root.defaultItems = MenuIndex.parseMenuJsonc(text()); root.rebuild(); }
         onFileChanged: reload()
+        // Without this the menu section would simply come up empty and give no
+        // reason why. The likely cause is OMARCHY_PATH not reaching the shell
+        // process, which matters on any install that is not under /usr/share.
+        onLoadFailed: {
+            console.warn("hancore.overview-workspaces: no menu definition at "
+                + root.defaultPath + " (OMARCHY_PATH="
+                + (Quickshell.env("OMARCHY_PATH") || "unset")
+                + ") -- command menu results will be unavailable");
+            root.defaultItems = [];
+            root.rebuild();
+        }
     }
 
     FileView {

--- a/MenuSearch.qml
+++ b/MenuSearch.qml
@@ -133,8 +133,8 @@ Singleton {
         onFileChanged: reload()
     }
 
-    // Script output format: "<id>:<tag>:<0|1>" per line. Only the "w" (when) tag
-    // matters here; "c" (checked) drives the menu's ✓ marker.
+    // The reply is read back by MenuIndex.parseGuardReply, which lives there with
+    // guardScript so the two halves of the protocol stay together and testable.
     Process {
         id: guardProc
         property string collected: ""
@@ -155,24 +155,7 @@ Singleton {
                     Qt.callLater(() => root.evaluateGuards());
                 return;
             }
-            const next = ({});
-            const lines = guardProc.collected.split("\n");
-            for (let i = 0; i < lines.length; ++i) {
-                const line = lines[i].trim();
-                if (!line)
-                    continue;
-                const colon = line.lastIndexOf(":");
-                if (colon < 0)
-                    continue;
-                const value = line.substring(colon + 1) === "1";
-                const rest = line.substring(0, colon);
-                const tagAt = rest.lastIndexOf(":");
-                if (tagAt < 0)
-                    continue;
-                if (rest.substring(tagAt + 1) === "w")
-                    next[rest.substring(0, tagAt)] = value;
-            }
-            root.whenResults = next;
+            root.whenResults = MenuIndex.parseGuardReply(guardProc.collected);
             if (root.guardsPending)
                 Qt.callLater(() => root.evaluateGuards());
         }

--- a/MenuSearch.qml
+++ b/MenuSearch.qml
@@ -40,14 +40,22 @@ Singleton {
         root.evaluateGuards();
     }
 
+    // A reload landing mid-run would otherwise be dropped, leaving whenResults
+    // describing the previous set of items. Remember that it happened and run
+    // again once the current batch exits.
+    property bool guardsPending: false
+
     function evaluateGuards() {
         const script = MenuIndex.guardScript(root.items);
         if (!script) {
             root.whenResults = ({});
             return;
         }
-        if (guardProc.running)
+        if (guardProc.running) {
+            root.guardsPending = true;
             return;
+        }
+        root.guardsPending = false;
         guardProc.collected = "";
         guardProc.command = ["bash", "-lc", script];
         guardProc.running = true;
@@ -121,8 +129,17 @@ Singleton {
         }
 
         onExited: (exitCode, exitStatus) => {
-            if (exitCode !== 0 || exitStatus !== 0)
+            // A batch that was killed rather than finished only reported the rows
+            // it reached, so the last complete set is kept instead of a partial
+            // one. Clearing it here would be worse than stale: with no answers at
+            // all every guarded action passes, which is exactly what evaluating
+            // guards is meant to prevent. A signal leaves the exit code at 0, so
+            // the status is what tells us.
+            if (exitCode !== 0 || exitStatus !== 0) {
+                if (root.guardsPending)
+                    Qt.callLater(() => root.evaluateGuards());
                 return;
+            }
             const next = ({});
             const lines = guardProc.collected.split("\n");
             for (let i = 0; i < lines.length; ++i) {
@@ -141,6 +158,8 @@ Singleton {
                     next[rest.substring(0, tagAt)] = value;
             }
             root.whenResults = next;
+            if (root.guardsPending)
+                Qt.callLater(() => root.evaluateGuards());
         }
     }
 }

--- a/MenuSearch.qml
+++ b/MenuSearch.qml
@@ -46,13 +46,16 @@ Singleton {
     property bool guardsPending: false
 
     function evaluateGuards() {
+        // The running check comes first: clearing whenResults for an item set with
+        // no guards while a batch is still in flight would let that batch write
+        // the previous set's answers back, with nothing queued to correct it.
+        if (guardProc.running) {
+            root.guardsPending = true;
+            return;
+        }
         const script = MenuIndex.guardScript(root.items);
         if (!script) {
             root.whenResults = ({});
-            return;
-        }
-        if (guardProc.running) {
-            root.guardsPending = true;
             return;
         }
         root.guardsPending = false;
@@ -99,6 +102,18 @@ Singleton {
             return false;
         Quickshell.execDetached(["bash", "-lc", command]);
         return true;
+    }
+
+    // Guards answer questions about live state -- whether a recording is running,
+    // whether a toggle is off -- so answers frozen at shell start go stale. Omarchy
+    // re-evaluates every time its menu opens; the equivalent moment here is the
+    // overview entering search mode.
+    Connections {
+        target: GlobalStates
+        function onOverviewSearchModeChanged() {
+            if (GlobalStates.overviewSearchMode)
+                root.evaluateGuards();
+        }
     }
 
     FileView {

--- a/MenuSearch.qml
+++ b/MenuSearch.qml
@@ -1,0 +1,145 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+import "."
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "MenuIndex.js" as MenuIndex
+
+// Busqueda dentro del command menu de Omarchy (el de Super+Space, id omarchy.menu).
+//
+// El modelo vive en MenuIndex.js, propio y autocontenido. No se importa el
+// MenuModel.js de Omarchy porque los imports de JS en QML son estaticos y la
+// ruta depende de $OMARCHY_PATH (en NixOS no es /usr/share/omarchy): una ruta
+// fija romperia la carga del plugin entero en vez de degradar la busqueda.
+//
+// Lo importante son los guards: 144 de las 263 acciones del menu traen un `when:`
+// (una condicion de shell). Sin evaluarlas ofreceriamos cosas como Hibernate en
+// una maquina que no hiberna. guardScript() arma UN solo script bash que las
+// resuelve todas de una pasada.
+Singleton {
+    id: root
+
+    // Misma razon que arriba: el prefijo de Omarchy sale del entorno, no se
+    // hardcodea. El fallback cubre el caso de que la variable no este seteada.
+    readonly property string omarchyPath: Quickshell.env("OMARCHY_PATH") || "/usr/share/omarchy"
+    readonly property string defaultPath: `${root.omarchyPath}/default/omarchy/omarchy-menu.jsonc`
+    readonly property string userPath: `${Quickshell.env("HOME")}/.config/omarchy/extensions/omarchy-menu.jsonc`
+
+    property var defaultItems: []
+    property var userItems: []
+    property var items: ({})
+    property var itemOrder: []
+    property var whenResults: ({})
+
+    function rebuild() {
+        const merged = MenuIndex.mergeMenuSources(root.defaultItems, root.userItems);
+        root.items = merged.items;
+        root.itemOrder = merged.itemOrder;
+        root.evaluateGuards();
+    }
+
+    function evaluateGuards() {
+        const script = MenuIndex.guardScript(root.items);
+        if (!script) {
+            root.whenResults = ({});
+            return;
+        }
+        if (guardProc.running)
+            return;
+        guardProc.collected = "";
+        guardProc.command = ["bash", "-lc", script];
+        guardProc.running = true;
+    }
+
+    // Solo filas ejecutables. Un `menu` abre un submenu y un `link` navega: ni
+    // uno ni otro tienen sentido como resultado suelto dentro del overview.
+    function query(text, limit) {
+        const needle = String(text || "").trim();
+        if (needle.length === 0)
+            return [];
+
+        const order = root.itemOrder || [];
+        const out = [];
+        for (let i = 0; i < order.length; ++i) {
+            const entry = MenuIndex.item(root.items, order[i]);
+            if (!entry || entry.kind !== "action" || !entry.action)
+                continue;
+            // Para un `action` la visibilidad es solo su propio guard: Omarchy
+            // tampoco mira los ancestros al resolver una fila ejecutable.
+            if (entry.when && root.whenResults[entry.id] === false)
+                continue;
+            if (!MenuIndex.matchesQuery(entry, needle))
+                continue;
+            out.push({
+                id: entry.id,
+                label: entry.label,
+                action: entry.action,
+                description: entry.description || "",
+                path: MenuIndex.parentPathFor(root.items, entry.id),
+                score: MenuIndex.searchScore(root.items, entry, needle)
+            });
+        }
+        out.sort((a, b) => a.score - b.score);
+        return out.slice(0, limit || 6);
+    }
+
+    function runAction(action) {
+        const command = String(action || "");
+        if (command.length === 0)
+            return false;
+        Quickshell.execDetached(["bash", "-lc", command]);
+        return true;
+    }
+
+    FileView {
+        path: root.defaultPath
+        watchChanges: true
+        printErrors: false
+        onLoaded: { root.defaultItems = MenuIndex.parseMenuJsonc(text()); root.rebuild(); }
+        onFileChanged: reload()
+    }
+
+    FileView {
+        path: root.userPath
+        watchChanges: true
+        printErrors: false
+        onLoaded: { root.userItems = MenuIndex.parseMenuJsonc(text()); root.rebuild(); }
+        onLoadFailed: { root.userItems = []; root.rebuild(); }
+        onFileChanged: reload()
+    }
+
+    // Formato de salida del script: "<id>:<tag>:<0|1>" por linea. Solo nos
+    // interesa el tag "w" (when); "c" (checked) es para el ✓ del menu.
+    Process {
+        id: guardProc
+        property string collected: ""
+
+        stdout: SplitParser {
+            onRead: data => { guardProc.collected += data + "\n"; }
+        }
+
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode !== 0 || exitStatus !== 0)
+                return;
+            const next = ({});
+            const lines = guardProc.collected.split("\n");
+            for (let i = 0; i < lines.length; ++i) {
+                const line = lines[i].trim();
+                if (!line)
+                    continue;
+                const colon = line.lastIndexOf(":");
+                if (colon < 0)
+                    continue;
+                const value = line.substring(colon + 1) === "1";
+                const rest = line.substring(0, colon);
+                const tagAt = rest.lastIndexOf(":");
+                if (tagAt < 0)
+                    continue;
+                if (rest.substring(tagAt + 1) === "w")
+                    next[rest.substring(0, tagAt)] = value;
+            }
+            root.whenResults = next;
+        }
+    }
+}

--- a/MenuSearch.qml
+++ b/MenuSearch.qml
@@ -6,22 +6,23 @@ import Quickshell
 import Quickshell.Io
 import "MenuIndex.js" as MenuIndex
 
-// Busqueda dentro del command menu de Omarchy (el de Super+Space, id omarchy.menu).
+// Search inside Omarchy's command menu (the Super+Space one, id omarchy.menu).
 //
-// El modelo vive en MenuIndex.js, propio y autocontenido. No se importa el
-// MenuModel.js de Omarchy porque los imports de JS en QML son estaticos y la
-// ruta depende de $OMARCHY_PATH (en NixOS no es /usr/share/omarchy): una ruta
-// fija romperia la carga del plugin entero en vez de degradar la busqueda.
+// The model lives in MenuIndex.js, written here and self-contained. Omarchy's
+// MenuModel.js is deliberately not imported: QML resolves JS imports statically
+// while Omarchy's prefix comes from $OMARCHY_PATH, which is not
+// /usr/share/omarchy on NixOS. A fixed path would fail to load the whole plugin
+// rather than degrade this one feature.
 //
-// Lo importante son los guards: 144 de las 263 acciones del menu traen un `when:`
-// (una condicion de shell). Sin evaluarlas ofreceriamos cosas como Hibernate en
-// una maquina que no hiberna. guardScript() arma UN solo script bash que las
-// resuelve todas de una pasada.
+// The guards are what matter: 144 of the menu's 263 actions carry a `when:`
+// shell condition. Without evaluating them we would offer things like Hibernate
+// on a machine that cannot hibernate. guardScript() resolves them all in a
+// single batched bash run.
 Singleton {
     id: root
 
-    // Misma razon que arriba: el prefijo de Omarchy sale del entorno, no se
-    // hardcodea. El fallback cubre el caso de que la variable no este seteada.
+    // Same reason as above: Omarchy's prefix comes from the environment rather
+    // than being hardcoded. The fallback covers an unset variable.
     readonly property string omarchyPath: Quickshell.env("OMARCHY_PATH") || "/usr/share/omarchy"
     readonly property string defaultPath: `${root.omarchyPath}/default/omarchy/omarchy-menu.jsonc`
     readonly property string userPath: `${Quickshell.env("HOME")}/.config/omarchy/extensions/omarchy-menu.jsonc`
@@ -52,8 +53,8 @@ Singleton {
         guardProc.running = true;
     }
 
-    // Solo filas ejecutables. Un `menu` abre un submenu y un `link` navega: ni
-    // uno ni otro tienen sentido como resultado suelto dentro del overview.
+    // Executable rows only. A `menu` opens a submenu and a `link` navigates;
+    // neither makes sense as a standalone result inside the overview.
     function query(text, limit) {
         const needle = String(text || "").trim();
         if (needle.length === 0)
@@ -65,8 +66,8 @@ Singleton {
             const entry = MenuIndex.item(root.items, order[i]);
             if (!entry || entry.kind !== "action" || !entry.action)
                 continue;
-            // Para un `action` la visibilidad es solo su propio guard: Omarchy
-            // tampoco mira los ancestros al resolver una fila ejecutable.
+            // For an `action`, visibility is just its own guard: Omarchy does not
+            // consult ancestors either when resolving an executable row.
             if (entry.when && root.whenResults[entry.id] === false)
                 continue;
             if (!MenuIndex.matchesQuery(entry, needle))
@@ -109,8 +110,8 @@ Singleton {
         onFileChanged: reload()
     }
 
-    // Formato de salida del script: "<id>:<tag>:<0|1>" por linea. Solo nos
-    // interesa el tag "w" (when); "c" (checked) es para el ✓ del menu.
+    // Script output format: "<id>:<tag>:<0|1>" per line. Only the "w" (when) tag
+    // matters here; "c" (checked) drives the menu's ✓ marker.
     Process {
         id: guardProc
         property string collected: ""

--- a/Overview.qml
+++ b/Overview.qml
@@ -300,8 +300,7 @@ Scope {
                         overviewScope.handleOverviewNavigationKey(event);
                         return;
                     }
-                    // ── Search mode keyboard handling (DISABLED: search UI removed) ──
-                    /*
+                    // ── Search mode keyboard handling ──
                     if (GlobalStates.overviewSearchMode) {
                         if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                             overviewSearch.activateSelection();
@@ -358,7 +357,6 @@ Scope {
                         event.accepted = true;
                         return;
                     }
-                    */
                     // Arrow keys navigate workspaces in workspace mode
                     if (!GlobalStates.overviewSearchMode) {
                         overviewScope.handleOverviewNavigationKey(event);

--- a/Overview.qml
+++ b/Overview.qml
@@ -286,7 +286,12 @@ Scope {
                         event.accepted = true;
                         return;
                     }
-                    if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {
+                    // Search mode owns Tab (it moves the result selection), so this
+                    // workspace-cycling branch has to stand down while it is on --
+                    // it returns unconditionally and would otherwise shadow the
+                    // search handler further down.
+                    if (!GlobalStates.overviewSearchMode
+                        && (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab)) {
                         const backward = (event.key === Qt.Key_Backtab) || ((event.modifiers & Qt.ShiftModifier) !== 0);
                         if (OverviewSwitchingController.grabbed) {
                             overviewScope.queueGrabbedCycle(backward ? -1 : 1);

--- a/Overview.qml
+++ b/Overview.qml
@@ -347,20 +347,28 @@ Scope {
                         overviewScope.handleOverviewNavigationKey(event);
                         return;
                     }
-                    // In workspace mode, any printable character enters search mode
-                    if (!GlobalStates.overviewSearchMode
-                        && event.text.length > 0
-                        && !(event.modifiers & Qt.ControlModifier)
-                        && !(event.modifiers & Qt.AltModifier)
-                        && !(event.modifiers & Qt.MetaModifier)
-                        && event.key !== Qt.Key_Backspace
-                        && event.key !== Qt.Key_Delete
-                        && event.key !== Qt.Key_Tab
-                        && event.key !== Qt.Key_Space) {
-                        overviewScope.overviewFilterQuery = event.text;
-                        GlobalStates.overviewSearchMode = true;
-                        event.accepted = true;
-                        return;
+                    // Entering search mode. With vim keys on, only "/" does it,
+                    // which leaves every letter -- h/j/k/l included -- free to
+                    // navigate; with them off the first character typed both opens
+                    // search and becomes the query.
+                    if (!GlobalStates.overviewSearchMode) {
+                        const plainKey = event.text.length > 0
+                            && !(event.modifiers & Qt.ControlModifier)
+                            && !(event.modifiers & Qt.AltModifier)
+                            && !(event.modifiers & Qt.MetaModifier)
+                            && event.key !== Qt.Key_Backspace
+                            && event.key !== Qt.Key_Delete
+                            && event.key !== Qt.Key_Tab
+                            && event.key !== Qt.Key_Space;
+                        const vim = GlobalStates.overviewVimKeys;
+                        if (vim ? (plainKey && event.key === Qt.Key_Slash) : plainKey) {
+                            // "/" is the trigger, not the first character of the
+                            // query, so it must not land in the text.
+                            overviewScope.overviewFilterQuery = vim ? "" : event.text;
+                            GlobalStates.overviewSearchMode = true;
+                            event.accepted = true;
+                            return;
+                        }
                     }
                     // Arrow keys navigate workspaces in workspace mode
                     if (!GlobalStates.overviewSearchMode) {

--- a/OverviewSearch.qml
+++ b/OverviewSearch.qml
@@ -160,9 +160,9 @@ Item {
     onQueryChanged: selectedIndex = 0
 
 
-    // Barra de query: muestra lo que se esta tipeando, encima de los overviews.
-    // Aparece apenas se entra en searchMode, incluso sin texto todavia, para que
-    // quede claro que el teclado ya no navega workspaces.
+    // Query bar: shows what is being typed, above the workspace cards. It appears
+    // as soon as search mode starts, even before any text, so it is clear the
+    // keyboard no longer navigates workspaces.
     Rectangle {
         id: queryBar
         property bool cursorOn: true
@@ -201,7 +201,7 @@ Item {
 
             StyledText {
                 Layout.fillWidth: true
-                text: root.hasQuery ? root.query : "Escribi para buscar    >  comando de shell"
+                text: root.hasQuery ? root.query : "Type to search    >  shell command"
                 color: root.hasQuery ? TuiStyle.fg : TuiStyle.dim
                 font.pixelSize: 15
                 elide: Text.ElideLeft
@@ -353,7 +353,7 @@ Item {
                     visible: root.totalResults === 0
                     text: root.commandMode
                         ? "Type a command after >"
-                        : "Sin coincidencias en apps, ventanas ni el menu"
+                        : "No matching applications, windows or menu actions"
                     color: TuiStyle.dim
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter

--- a/OverviewSearch.qml
+++ b/OverviewSearch.qml
@@ -163,6 +163,44 @@ Item {
     // Query bar: shows what is being typed, above the workspace cards. It appears
     // as soon as search mode starts, even before any text, so it is clear the
     // keyboard no longer navigates workspaces.
+    // Where the query bar will appear. With vim keys on, search is otherwise
+    // invisible: nothing on screen says the key exists.
+    Rectangle {
+        id: searchHint
+        anchors {
+            top: parent.top
+            topMargin: 24
+            horizontalCenter: parent.horizontalCenter
+        }
+        width: hintRow.implicitWidth + 24
+        height: 30
+        visible: root.searchMode === false
+            && GlobalStates.overviewVimKeys
+        radius: 6
+        color: TuiStyle.surfaceSubtle
+        border.width: 1
+        border.color: TuiStyle.inactiveBorder
+        opacity: 0.75
+
+        RowLayout {
+            id: hintRow
+            anchors.centerIn: parent
+            spacing: 7
+
+            NerdIcon {
+                symbol: "search"
+                iconSize: 13
+                color: TuiStyle.dim
+            }
+
+            StyledText {
+                text: "Press  /  to search"
+                color: TuiStyle.dim
+                font.pixelSize: 12
+            }
+        }
+    }
+
     Rectangle {
         id: queryBar
         property bool cursorOn: true
@@ -201,7 +239,9 @@ Item {
 
             StyledText {
                 Layout.fillWidth: true
-                text: root.hasQuery ? root.query : "Type to search    >  shell command"
+                text: root.hasQuery
+                    ? root.query
+                    : "Search apps, windows and the menu    >  shell command"
                 color: root.hasQuery ? TuiStyle.fg : TuiStyle.dim
                 font.pixelSize: 15
                 elide: Text.ElideLeft

--- a/OverviewSearch.qml
+++ b/OverviewSearch.qml
@@ -15,6 +15,7 @@ Item {
     property int selectedIndex: 0
     property int maxAppResults: 5
     property int maxWindowResults: 7
+    property int maxMenuResults: 6
 
     readonly property string normalizedQuery: query.trim()
     readonly property bool commandMode: normalizedQuery.startsWith(">")
@@ -26,8 +27,12 @@ Item {
     readonly property var windowResults: hasQuery && !commandMode
         ? root.filterWindows(normalizedQuery).slice(0, maxWindowResults)
         : []
+    readonly property var menuResults: hasQuery && !commandMode
+        ? MenuSearch.query(normalizedQuery, maxMenuResults)
+        : []
     readonly property int commandResultCount: commandMode && commandText.length > 0 ? 1 : 0
-    readonly property int totalResults: commandResultCount + appResults.length + windowResults.length
+    readonly property int totalResults: commandResultCount + appResults.length
+        + windowResults.length + menuResults.length
     readonly property int popupWidth: Math.min(760, Math.max(520, width - 80))
 
     signal searchRequested()
@@ -102,6 +107,13 @@ Item {
         GlobalStates.overviewOpen = false;
     }
 
+    function runMenuAction(row) {
+        if (!row)
+            return;
+        MenuSearch.runAction(row.action);
+        GlobalStates.overviewOpen = false;
+    }
+
     function activateSelection() {
         if (commandResultCount > 0) {
             executeCommand();
@@ -112,8 +124,13 @@ Item {
             return;
         }
         const windowIndex = selectedIndex - appResults.length;
-        if (windowIndex >= 0 && windowIndex < windowResults.length)
+        if (windowIndex >= 0 && windowIndex < windowResults.length) {
             focusWindow(windowResults[windowIndex]);
+            return;
+        }
+        const menuIndex = windowIndex - windowResults.length;
+        if (menuIndex >= 0 && menuIndex < menuResults.length)
+            runMenuAction(menuResults[menuIndex]);
     }
 
     function windowTitle(win) {
@@ -143,11 +160,75 @@ Item {
     onQueryChanged: selectedIndex = 0
 
 
+    // Barra de query: muestra lo que se esta tipeando, encima de los overviews.
+    // Aparece apenas se entra en searchMode, incluso sin texto todavia, para que
+    // quede claro que el teclado ya no navega workspaces.
     Rectangle {
-        id: resultsPopup
+        id: queryBar
+        property bool cursorOn: true
+
         anchors {
             top: parent.top
             topMargin: 24
+            horizontalCenter: parent.horizontalCenter
+        }
+        width: root.popupWidth
+        height: 46
+        visible: root.searchMode
+        radius: 8
+        color: TuiStyle.bg
+        border.width: 1
+        border.color: root.commandMode ? TuiStyle.accent : TuiStyle.menuBorder
+
+        Timer {
+            running: queryBar.visible
+            interval: 530
+            repeat: true
+            onTriggered: queryBar.cursorOn = !queryBar.cursorOn
+        }
+
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: 14
+            anchors.rightMargin: 14
+            spacing: 10
+
+            NerdIcon {
+                symbol: root.commandMode ? "terminal" : "search"
+                iconSize: 18
+                color: root.commandMode ? TuiStyle.accent : TuiStyle.dim
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                text: root.hasQuery ? root.query : "Escribi para buscar    >  comando de shell"
+                color: root.hasQuery ? TuiStyle.fg : TuiStyle.dim
+                font.pixelSize: 15
+                elide: Text.ElideLeft
+            }
+
+            Rectangle {
+                Layout.preferredWidth: 2
+                Layout.preferredHeight: 19
+                color: TuiStyle.accent
+                opacity: queryBar.cursorOn ? 1 : 0
+                visible: root.hasQuery
+            }
+
+            StyledText {
+                visible: root.totalResults > 0
+                text: `${root.selectedIndex + 1}/${root.totalResults}`
+                color: TuiStyle.dim
+                font.pixelSize: 11
+            }
+        }
+    }
+
+    Rectangle {
+        id: resultsPopup
+        anchors {
+            top: queryBar.bottom
+            topMargin: 8
             horizontalCenter: parent.horizontalCenter
         }
         width: root.popupWidth
@@ -242,13 +323,37 @@ Item {
                     }
                 }
 
+                SearchSectionHeader {
+                    Layout.fillWidth: true
+                    visible: root.menuResults.length > 0
+                    label: "Command Menu"
+                    count: root.menuResults.length
+                }
+
+                Repeater {
+                    model: root.menuResults
+
+                    SearchResultRow {
+                        required property var modelData
+                        required property int index
+                        Layout.fillWidth: true
+                        resultIndex: root.appResults.length + root.windowResults.length + index
+                        title: modelData?.label || ""
+                        subtitle: modelData?.description || modelData?.action || ""
+                        meta: modelData?.path || "Omarchy menu"
+                        symbol: "menu"
+                        selected: root.selectedIndex === resultIndex
+                        onActivated: root.runMenuAction(modelData)
+                    }
+                }
+
                 StyledText {
                     Layout.fillWidth: true
                     Layout.preferredHeight: 48
                     visible: root.totalResults === 0
                     text: root.commandMode
                         ? "Type a command after >"
-                        : "No matching applications or windows"
+                        : "Sin coincidencias en apps, ventanas ni el menu"
                     color: TuiStyle.dim
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter

--- a/OverviewWidget.qml
+++ b/OverviewWidget.qml
@@ -37,7 +37,24 @@ Item {
         void _rev;
         if (OverviewSwitchingController.grabbed)
             return WorkspaceNavigation.switchingModeModel() ?? [];
-        return root.filteredOverviewEntries(ServiceManager.workspace.overviewWorkspaceEntries ?? []);
+        return root.filteredOverviewEntries(root.scopedOverviewEntries());
+    }
+
+    // En modo per-monitor cada overlay pide las entries de su propia pantalla en
+    // vez de la lista global. Filtrar aca y no en el render deja intactos los
+    // calculos de grilla, alto y aspecto: monitorGroups se deriva de esta lista,
+    // asi que pasa a tener un solo grupo sin tocar el layout.
+    function scopedOverviewEntries() {
+        const all = ServiceManager.workspace.overviewWorkspaceEntries ?? [];
+        if (!(Config?.options.overview.perMonitor ?? true))
+            return all;
+        const name = root.monitor?.name ?? "";
+        if (name.length === 0)
+            return all;
+        const own = ServiceManager.workspace.overviewWorkspaceEntriesForMonitor(name, true, {}, false) ?? [];
+        // Si Hyprland todavia no reporto este monitor, mostrar todo es mejor
+        // que dejar la pantalla en blanco.
+        return own.length > 0 ? own : all;
     }
     readonly property var overviewEntryIds: (root.overviewEntries ?? []).map(entry => entry.id)
     readonly property var searchMatchWorkspaceIds: {

--- a/OverviewWidget.qml
+++ b/OverviewWidget.qml
@@ -773,17 +773,17 @@ Item {
                         onPressed: {
                             if (GlobalStates.overviewDraggingTargetWorkspace === -1) {
                                 if (workspace.isTrailingEmpty) {
-                                    GlobalStates.overviewOpen = false;
                                     if (workspace.monitorName.length > 0)
                                         Hyprland.dispatch(`hl.dsp.focus({monitor="${workspace.monitorName}"})`);
                                     Hyprland.dispatch(`hl.dsp.focus({ workspace = ${workspace.workspaceValue} })`);
                                     if (workspace.monitorName.length > 0)
                                         Hyprland.dispatch(`hl.dsp.workspace.move({ workspace = "${workspace.workspaceValue}", monitor = "${workspace.monitorName}" })`);
+                                    GlobalStates.overviewOpen = false;
                                 } else {
                                     if (ServiceManager.workspace.workspaceHasVisibleWindows(workspace.workspaceValue))
                                         GlobalStates.promoteWorkspaceMru(workspace.workspaceValue);
-                                    GlobalStates.overviewOpen = false;
                                     root.dispatchFocusWorkspace(workspace.workspaceValue);
+                                    GlobalStates.overviewOpen = false;
                                 }
                             }
                         }
@@ -978,8 +978,14 @@ Item {
                             if (!window.windowData) return;
 
                             if (event.button === Qt.LeftButton) {
-                                GlobalStates.overviewOpen = false;
+                                // Dispatch before dismissing. Closing the layer
+                                // surface first hands focus back to whatever was
+                                // active, and that restore races the focus we are
+                                // about to ask for -- when it wins, the click
+                                // appears to do nothing and the previous window
+                                // stays. OverviewSearch already ordered it this way.
                                 WorkspaceNavigation.focusWindow(window.windowData);
+                                GlobalStates.overviewOpen = false;
                                 event.accepted = true;
                             } else if (event.button === Qt.MiddleButton) {
                                 Hyprland.dispatch(`hl.dsp.window.close({window = "address:${window.windowData.address}"})`)

--- a/OverviewWidget.qml
+++ b/OverviewWidget.qml
@@ -46,7 +46,7 @@ Item {
     // asi que pasa a tener un solo grupo sin tocar el layout.
     function scopedOverviewEntries() {
         const all = ServiceManager.workspace.overviewWorkspaceEntries ?? [];
-        if (!(Config?.options.overview.perMonitor ?? true))
+        if (!GlobalStates.overviewPerMonitor)
             return all;
         const name = root.monitor?.name ?? "";
         if (name.length === 0)

--- a/OverviewWidget.qml
+++ b/OverviewWidget.qml
@@ -40,10 +40,10 @@ Item {
         return root.filteredOverviewEntries(root.scopedOverviewEntries());
     }
 
-    // En modo per-monitor cada overlay pide las entries de su propia pantalla en
-    // vez de la lista global. Filtrar aca y no en el render deja intactos los
-    // calculos de grilla, alto y aspecto: monitorGroups se deriva de esta lista,
-    // asi que pasa a tener un solo grupo sin tocar el layout.
+    // In per-monitor mode each overlay asks for its own screen's entries instead
+    // of the global list. Scoping here rather than in the renderer leaves the
+    // grid, height and aspect maths untouched: monitorGroups is derived from this
+    // list, so it collapses to a single group on its own.
     function scopedOverviewEntries() {
         const all = ServiceManager.workspace.overviewWorkspaceEntries ?? [];
         if (!GlobalStates.overviewPerMonitor)
@@ -52,8 +52,8 @@ Item {
         if (name.length === 0)
             return all;
         const own = ServiceManager.workspace.overviewWorkspaceEntriesForMonitor(name, true, {}, false) ?? [];
-        // Si Hyprland todavia no reporto este monitor, mostrar todo es mejor
-        // que dejar la pantalla en blanco.
+        // If Hyprland has not reported this monitor yet, showing everything beats
+        // leaving the screen blank.
         return own.length > 0 ? own : all;
     }
     readonly property var overviewEntryIds: (root.overviewEntries ?? []).map(entry => entry.id)

--- a/SettingsPanel.qml
+++ b/SettingsPanel.qml
@@ -19,8 +19,8 @@ Panel {
     function close() { root.controller.hide() }
     function toggle() { root.opened ? root.close() : root.open() }
 
-    // Solo tiene sentido ofrecer el alcance del preview cuando hay mas de una
-    // pantalla: con un monitor las dos opciones dibujan exactamente lo mismo.
+    // The preview scope is only worth offering with more than one screen: on a
+    // single monitor both settings draw exactly the same grid.
     readonly property bool multiMonitor: (ServiceManager.workspace.monitors?.length ?? 0) > 1
 
     function persistSetting(key, value) {

--- a/SettingsPanel.qml
+++ b/SettingsPanel.qml
@@ -19,14 +19,17 @@ Panel {
     function close() { root.controller.hide() }
     function toggle() { root.opened ? root.close() : root.open() }
 
-    function persistMode(mode) {
-        GlobalStates.overviewSortMode = mode === "legacy" ? "legacy" : "system";
+    // Solo tiene sentido ofrecer el alcance del preview cuando hay mas de una
+    // pantalla: con un monitor las dos opciones dibujan exactamente lo mismo.
+    readonly property bool multiMonitor: (ServiceManager.workspace.monitors?.length ?? 0) > 1
+
+    function persistSetting(key, value) {
         var entry = { id: root.moduleName };
-        for (var key in root.settings) {
-            if (key !== "id")
-                entry[key] = root.settings[key];
+        for (var existing in root.settings) {
+            if (existing !== "id")
+                entry[existing] = root.settings[existing];
         }
-        entry.sortMode = mode;
+        entry[key] = value;
         root.settings = entry;
         if (root.hostWidget && "settings" in root.hostWidget)
             root.hostWidget.settings = entry;
@@ -34,9 +37,20 @@ Panel {
             root.bar.shell.updateEntryInline(root.moduleName, entry);
     }
 
+    function persistMode(mode) {
+        GlobalStates.overviewSortMode = mode === "legacy" ? "legacy" : "system";
+        root.persistSetting("sortMode", mode);
+    }
+
+    function persistPerMonitor(enabled) {
+        GlobalStates.overviewPerMonitor = enabled;
+        root.persistSetting("perMonitor", enabled);
+    }
+
     function syncSettings() {
         const mode = root.setting("sortMode", "legacy") === "legacy" ? "legacy" : "system";
         GlobalStates.overviewSortMode = mode;
+        GlobalStates.overviewPerMonitor = root.setting("perMonitor", true) !== false;
     }
 
     Component.onCompleted: {
@@ -147,6 +161,96 @@ Panel {
                                     anchors.fill: parent
                                     onClicked: root.persistMode(modelData.key)
                                 }
+                            }
+                        }
+
+                        Rectangle {
+                            width: menuColumn.width
+                            height: 1
+                            visible: root.multiMonitor
+                            color: Util.alpha(Color.popups.text, 0.12)
+                        }
+
+                        Text {
+                            visible: root.multiMonitor
+                            text: "Multi-monitor preview"
+                            width: parent.width
+                            wrapMode: Text.WordWrap
+                            color: root.panelForeground
+                            font.family: root.bar ? root.bar.fontFamily : Style.font.family
+                            font.pixelSize: Style.font.title
+                            font.bold: true
+                        }
+
+                        Rectangle {
+                            id: perMonitorRow
+                            visible: root.multiMonitor
+                            width: menuColumn.width
+                            height: perMonitorColumn.implicitHeight + Style.space(16)
+                            color: GlobalStates.overviewPerMonitor
+                                ? Qt.rgba(Color.accent.r, Color.accent.g, Color.accent.b, 0.18)
+                                : Util.alpha(Color.popups.text, 0.06)
+                            border.width: 1
+                            border.color: GlobalStates.overviewPerMonitor ? Color.accent : Color.popups.border
+
+                            Column {
+                                id: perMonitorColumn
+                                anchors.left: parent.left
+                                anchors.right: statePill.left
+                                anchors.verticalCenter: parent.verticalCenter
+                                anchors.leftMargin: Style.space(8)
+                                anchors.rightMargin: Style.space(8)
+                                spacing: Style.space(2)
+
+                                Text {
+                                    text: "Show only this monitor's workspaces"
+                                    width: parent.width
+                                    wrapMode: Text.WordWrap
+                                    color: root.panelForeground
+                                    font.family: root.bar ? root.bar.fontFamily : Style.font.family
+                                    font.pixelSize: Style.font.body
+                                    font.bold: true
+                                }
+                                Text {
+                                    text: GlobalStates.overviewPerMonitor
+                                        ? "Each screen draws its own workspaces."
+                                        : "Every screen draws all workspaces, including the other monitors'."
+                                    width: parent.width
+                                    wrapMode: Text.WordWrap
+                                    color: root.panelMuted
+                                    font.family: root.bar ? root.bar.fontFamily : Style.font.family
+                                    font.pixelSize: Style.font.caption
+                                }
+                            }
+
+                            Rectangle {
+                                id: statePill
+                                anchors.right: parent.right
+                                anchors.verticalCenter: parent.verticalCenter
+                                anchors.rightMargin: Style.space(8)
+                                width: pillLabel.implicitWidth + Style.space(16)
+                                height: pillLabel.implicitHeight + Style.space(6)
+                                radius: height / 2
+                                color: GlobalStates.overviewPerMonitor
+                                    ? Color.accent
+                                    : Util.alpha(Color.popups.text, 0.14)
+
+                                Text {
+                                    id: pillLabel
+                                    anchors.centerIn: parent
+                                    text: GlobalStates.overviewPerMonitor ? "ON" : "OFF"
+                                    color: GlobalStates.overviewPerMonitor
+                                        ? Color.popups.background
+                                        : root.panelMuted
+                                    font.family: root.bar ? root.bar.fontFamily : Style.font.family
+                                    font.pixelSize: Style.font.caption
+                                    font.bold: true
+                                }
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: root.persistPerMonitor(!GlobalStates.overviewPerMonitor)
                             }
                         }
                     }

--- a/SettingsPanel.qml
+++ b/SettingsPanel.qml
@@ -47,10 +47,16 @@ Panel {
         root.persistSetting("perMonitor", enabled);
     }
 
+    function persistVimKeys(enabled) {
+        GlobalStates.overviewVimKeys = enabled;
+        root.persistSetting("vimKeys", enabled);
+    }
+
     function syncSettings() {
         const mode = root.setting("sortMode", "legacy") === "legacy" ? "legacy" : "system";
         GlobalStates.overviewSortMode = mode;
         GlobalStates.overviewPerMonitor = root.setting("perMonitor", true) !== false;
+        GlobalStates.overviewVimKeys = root.setting("vimKeys", true) !== false;
     }
 
     Component.onCompleted: {
@@ -58,6 +64,77 @@ Panel {
     }
 
     onSettingsChanged: root.syncSettings()
+
+    // Both settings below are a labelled row with an ON/OFF pill, so the shape
+    // lives here once instead of being spelled out twice.
+    component ToggleRow: Rectangle {
+        id: row
+        required property string title
+        required property string detail
+        required property bool checked
+        signal toggled()
+
+        height: rowText.implicitHeight + Style.space(16)
+        color: row.checked
+            ? Qt.rgba(Color.accent.r, Color.accent.g, Color.accent.b, 0.18)
+            : Util.alpha(Color.popups.text, 0.06)
+        border.width: 1
+        border.color: row.checked ? Color.accent : Color.popups.border
+
+        Column {
+            id: rowText
+            anchors.left: parent.left
+            anchors.right: pill.left
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.leftMargin: Style.space(8)
+            anchors.rightMargin: Style.space(8)
+            spacing: Style.space(2)
+
+            Text {
+                text: row.title
+                width: parent.width
+                wrapMode: Text.WordWrap
+                color: root.panelForeground
+                font.family: root.bar ? root.bar.fontFamily : Style.font.family
+                font.pixelSize: Style.font.body
+                font.bold: true
+            }
+            Text {
+                text: row.detail
+                width: parent.width
+                wrapMode: Text.WordWrap
+                color: root.panelMuted
+                font.family: root.bar ? root.bar.fontFamily : Style.font.family
+                font.pixelSize: Style.font.caption
+            }
+        }
+
+        Rectangle {
+            id: pill
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.rightMargin: Style.space(8)
+            width: pillLabel.implicitWidth + Style.space(16)
+            height: pillLabel.implicitHeight + Style.space(6)
+            radius: height / 2
+            color: row.checked ? Color.accent : Util.alpha(Color.popups.text, 0.14)
+
+            Text {
+                id: pillLabel
+                anchors.centerIn: parent
+                text: row.checked ? "ON" : "OFF"
+                color: row.checked ? Color.popups.background : root.panelMuted
+                font.family: root.bar ? root.bar.fontFamily : Style.font.family
+                font.pixelSize: Style.font.caption
+                font.bold: true
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: row.toggled()
+        }
+    }
 
     KeyboardPanel {
         id: panel
@@ -167,6 +244,32 @@ Panel {
                         Rectangle {
                             width: menuColumn.width
                             height: 1
+                            color: Util.alpha(Color.popups.text, 0.12)
+                        }
+
+                        Text {
+                            text: "Overview search"
+                            width: parent.width
+                            wrapMode: Text.WordWrap
+                            color: root.panelForeground
+                            font.family: root.bar ? root.bar.fontFamily : Style.font.family
+                            font.pixelSize: Style.font.title
+                            font.bold: true
+                        }
+
+                        ToggleRow {
+                            width: menuColumn.width
+                            title: "Keep h/j/k/l for navigation"
+                            detail: GlobalStates.overviewVimKeys
+                                ? "Press / to open search."
+                                : "Any letter opens search."
+                            checked: GlobalStates.overviewVimKeys
+                            onToggled: root.persistVimKeys(!GlobalStates.overviewVimKeys)
+                        }
+
+                        Rectangle {
+                            width: menuColumn.width
+                            height: 1
                             visible: root.multiMonitor
                             color: Util.alpha(Color.popups.text, 0.12)
                         }
@@ -182,76 +285,15 @@ Panel {
                             font.bold: true
                         }
 
-                        Rectangle {
-                            id: perMonitorRow
-                            visible: root.multiMonitor
+                        ToggleRow {
                             width: menuColumn.width
-                            height: perMonitorColumn.implicitHeight + Style.space(16)
-                            color: GlobalStates.overviewPerMonitor
-                                ? Qt.rgba(Color.accent.r, Color.accent.g, Color.accent.b, 0.18)
-                                : Util.alpha(Color.popups.text, 0.06)
-                            border.width: 1
-                            border.color: GlobalStates.overviewPerMonitor ? Color.accent : Color.popups.border
-
-                            Column {
-                                id: perMonitorColumn
-                                anchors.left: parent.left
-                                anchors.right: statePill.left
-                                anchors.verticalCenter: parent.verticalCenter
-                                anchors.leftMargin: Style.space(8)
-                                anchors.rightMargin: Style.space(8)
-                                spacing: Style.space(2)
-
-                                Text {
-                                    text: "Show only this monitor's workspaces"
-                                    width: parent.width
-                                    wrapMode: Text.WordWrap
-                                    color: root.panelForeground
-                                    font.family: root.bar ? root.bar.fontFamily : Style.font.family
-                                    font.pixelSize: Style.font.body
-                                    font.bold: true
-                                }
-                                Text {
-                                    text: GlobalStates.overviewPerMonitor
-                                        ? "Each screen draws its own workspaces."
-                                        : "Every screen draws all workspaces, including the other monitors'."
-                                    width: parent.width
-                                    wrapMode: Text.WordWrap
-                                    color: root.panelMuted
-                                    font.family: root.bar ? root.bar.fontFamily : Style.font.family
-                                    font.pixelSize: Style.font.caption
-                                }
-                            }
-
-                            Rectangle {
-                                id: statePill
-                                anchors.right: parent.right
-                                anchors.verticalCenter: parent.verticalCenter
-                                anchors.rightMargin: Style.space(8)
-                                width: pillLabel.implicitWidth + Style.space(16)
-                                height: pillLabel.implicitHeight + Style.space(6)
-                                radius: height / 2
-                                color: GlobalStates.overviewPerMonitor
-                                    ? Color.accent
-                                    : Util.alpha(Color.popups.text, 0.14)
-
-                                Text {
-                                    id: pillLabel
-                                    anchors.centerIn: parent
-                                    text: GlobalStates.overviewPerMonitor ? "ON" : "OFF"
-                                    color: GlobalStates.overviewPerMonitor
-                                        ? Color.popups.background
-                                        : root.panelMuted
-                                    font.family: root.bar ? root.bar.fontFamily : Style.font.family
-                                    font.pixelSize: Style.font.caption
-                                    font.bold: true
-                                }
-                            }
-
-                            MouseArea {
-                                anchors.fill: parent
-                                onClicked: root.persistPerMonitor(!GlobalStates.overviewPerMonitor)
-                            }
+                            visible: root.multiMonitor
+                            title: "Show only this monitor's workspaces"
+                            detail: GlobalStates.overviewPerMonitor
+                                ? "Each screen draws its own workspaces."
+                                : "Every screen draws all workspaces, including the other monitors'."
+                            checked: GlobalStates.overviewPerMonitor
+                            onToggled: root.persistPerMonitor(!GlobalStates.overviewPerMonitor)
                         }
                     }
                 }

--- a/WorkspaceNavigation.qml
+++ b/WorkspaceNavigation.qml
@@ -29,7 +29,7 @@ Singleton {
         // El teclado tiene que recorrer exactamente las tarjetas que se ven. Sin
         // esto, en per-monitor las flechas saltan a workspaces del otro monitor
         // que este overlay no dibuja.
-        if (Config?.options.overview.perMonitor ?? true) {
+        if (GlobalStates.overviewPerMonitor) {
             const anchor = GlobalStates.overviewAnchorMonitorName
                 || Hyprland.focusedMonitor?.name
                 || "";

--- a/WorkspaceNavigation.qml
+++ b/WorkspaceNavigation.qml
@@ -26,6 +26,19 @@ Singleton {
     function overviewModel() {
         if (OverviewSwitchingController.grabbed)
             return switchingModeModel();
+        // El teclado tiene que recorrer exactamente las tarjetas que se ven. Sin
+        // esto, en per-monitor las flechas saltan a workspaces del otro monitor
+        // que este overlay no dibuja.
+        if (Config?.options.overview.perMonitor ?? true) {
+            const anchor = GlobalStates.overviewAnchorMonitorName
+                || Hyprland.focusedMonitor?.name
+                || "";
+            if (anchor.length > 0) {
+                const scoped = ServiceManager.workspace.overviewWorkspaceEntriesForMonitor(anchor, true, {}, false);
+                if (scoped.length > 0)
+                    return scoped;
+            }
+        }
         return ServiceManager.workspace.overviewWorkspaceEntriesGroupedByMonitor();
     }
 

--- a/WorkspaceNavigation.qml
+++ b/WorkspaceNavigation.qml
@@ -26,9 +26,9 @@ Singleton {
     function overviewModel() {
         if (OverviewSwitchingController.grabbed)
             return switchingModeModel();
-        // El teclado tiene que recorrer exactamente las tarjetas que se ven. Sin
-        // esto, en per-monitor las flechas saltan a workspaces del otro monitor
-        // que este overlay no dibuja.
+        // The keyboard must walk exactly the cards on screen. Without this, in
+        // per-monitor mode the arrow keys step onto workspaces belonging to another
+        // monitor that this overlay does not draw.
         if (GlobalStates.overviewPerMonitor) {
             const anchor = GlobalStates.overviewAnchorMonitorName
                 || Hyprland.focusedMonitor?.name

--- a/bar/widget.qml
+++ b/bar/widget.qml
@@ -36,6 +36,9 @@ BarWidget {
     function applySettings() {
         Local.GlobalStates.overviewSortMode = setting("sortMode", "legacy") === "legacy"
             ? "legacy" : "system";
+        // El widget de barra es el unico punto que corre siempre al arrancar el
+        // shell; el SettingsPanel solo se sincroniza cuando se lo abre.
+        Local.GlobalStates.overviewPerMonitor = setting("perMonitor", true) !== false;
     }
     function open() { if (settingsPanelLoader.item) settingsPanelLoader.item.open(); }
     function close() { if (settingsPanelLoader.item) settingsPanelLoader.item.close(); }

--- a/bar/widget.qml
+++ b/bar/widget.qml
@@ -39,6 +39,7 @@ BarWidget {
         // The bar widget is the only place that always runs at shell startup;
         // SettingsPanel only syncs once the panel is instantiated.
         Local.GlobalStates.overviewPerMonitor = setting("perMonitor", true) !== false;
+        Local.GlobalStates.overviewVimKeys = setting("vimKeys", true) !== false;
     }
     function open() { if (settingsPanelLoader.item) settingsPanelLoader.item.open(); }
     function close() { if (settingsPanelLoader.item) settingsPanelLoader.item.close(); }

--- a/bar/widget.qml
+++ b/bar/widget.qml
@@ -36,8 +36,8 @@ BarWidget {
     function applySettings() {
         Local.GlobalStates.overviewSortMode = setting("sortMode", "legacy") === "legacy"
             ? "legacy" : "system";
-        // El widget de barra es el unico punto que corre siempre al arrancar el
-        // shell; el SettingsPanel solo se sincroniza cuando se lo abre.
+        // The bar widget is the only place that always runs at shell startup;
+        // SettingsPanel only syncs once the panel is instantiated.
         Local.GlobalStates.overviewPerMonitor = setting("perMonitor", true) !== false;
     }
     function open() { if (settingsPanelLoader.item) settingsPanelLoader.item.open(); }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "omarchy-overview-workspaces-tests",
+  "private": true,
+  "description": "Test harness for MenuIndex.js. The plugin itself is QML and needs no build step; this exists only so `npm test` has somewhere to live.",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/qmldir
+++ b/qmldir
@@ -1,5 +1,6 @@
 module hancore.overview.workspaces
 singleton AppSearch 1.0 AppSearch.qml
+singleton MenuSearch 1.0 MenuSearch.qml
 singleton Appearance 1.0 Appearance.qml
 singleton Config 1.0 Config.qml
 singleton Directories 1.0 Directories.qml

--- a/tests/fixtures/menu.jsonc
+++ b/tests/fixtures/menu.jsonc
@@ -1,0 +1,24 @@
+{
+  // Trimmed stand-in for Omarchy's omarchy-menu.jsonc, shaped like the real
+  // thing: dotted ids imply hierarchy, kind is inferred, and `when` is a shell
+  // condition. Kept in-repo so the suite does not need Omarchy installed.
+  "system": {"icon":"","label":"System","aliases":["power-menu"]},
+  "system.lock": {"icon":"","label":"Lock","action":"omarchy-system-lock"},
+  "system.suspend": {"label":"Suspend","when":"true","action":"systemctl suspend"},
+  "system.hibernate": {"label":"Hibernate","when":"false","action":"systemctl hibernate"},
+
+  "style": {"label":"Style"},
+  "style.theme": {"label":"Theme","description":"change the colour scheme","action":"omarchy-theme-switcher"},
+
+  // Not overridden by the user fixture, so its description survives the merge.
+  "setup": {"label":"Setup"},
+  "setup.dns": {"label":"DNS","description":"pick a resolver","action":"omarchy-dns-set"},
+
+  "install": {"label":"Install"},
+  "install.docker": {"label":"Docker","aliases":["container-runtime"],"action":"omarchy-install-docker"},
+
+  // A submenu carries no action, so it must never surface as a result.
+  "learn": {"label":"Learn"},
+  // A link navigates rather than executing.
+  "learn.docs": {"label":"Docs","target":"https://omarchy.org"},
+}

--- a/tests/fixtures/user-menu.jsonc
+++ b/tests/fixtures/user-menu.jsonc
@@ -1,0 +1,5 @@
+{
+  // Overrides the default entry with the same id, and adds one of its own.
+  "style.theme": {"label":"Colour theme","action":"my-theme-switcher"},
+  "custom.note": {"label":"Note","action":"my-note"},
+}

--- a/tests/menu-index.test.js
+++ b/tests/menu-index.test.js
@@ -1,0 +1,279 @@
+// Tests for MenuIndex.js, the searchable index behind the overview's command
+// menu results. Run with: node --test tests/
+//
+// MenuIndex.js is plain JS with no QML dependencies, so it loads directly under
+// Node. The fixtures are kept in-repo rather than read from $OMARCHY_PATH, so
+// the suite runs anywhere -- including CI, where Omarchy is not installed.
+//
+// The QML around it (MenuSearch, OverviewSearch) is out of scope here; that
+// would need qmltestrunner.
+
+const { test, describe } = require("node:test");
+const assert = require("node:assert");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const M = require("../MenuIndex.js");
+const FIXTURES = path.join(__dirname, "fixtures");
+
+const readFixture = name => fs.readFileSync(path.join(FIXTURES, name), "utf8");
+const defaultItems = () => M.parseMenuJsonc(readFixture("menu.jsonc"));
+const userItems = () => M.parseMenuJsonc(readFixture("user-menu.jsonc"));
+const merged = () => M.mergeMenuSources(defaultItems(), userItems());
+
+describe("stripJsonc", () => {
+    test("drops whole-line comments and trailing commas", () => {
+        const raw = `{
+  // a comment
+  "a": {"label":"A"},
+}`;
+        assert.deepStrictEqual(JSON.parse(M.stripJsonc(raw)), { a: { label: "A" } });
+    });
+
+    test("leaves a // inside a string alone", () => {
+        const raw = '{"a":{"target":"https://omarchy.org"}}';
+        assert.strictEqual(JSON.parse(M.stripJsonc(raw)).a.target, "https://omarchy.org");
+    });
+});
+
+describe("parseMenuJsonc", () => {
+    test("infers kind from the fields present", () => {
+        const byId = {};
+        for (const entry of defaultItems())
+            byId[entry.id] = entry;
+        assert.strictEqual(byId["system.lock"].kind, "action", "action field -> action");
+        assert.strictEqual(byId["learn.docs"].kind, "link", "target field -> link");
+        assert.strictEqual(byId["learn"].kind, "menu", "neither -> menu");
+    });
+
+    test("derives the parent from the dotted id", () => {
+        const byId = {};
+        for (const entry of defaultItems())
+            byId[entry.id] = entry;
+        assert.strictEqual(byId["system.lock"].parent, "system");
+        assert.strictEqual(byId["system"].parent, "root");
+    });
+
+    test("returns an empty list for malformed input rather than throwing", () => {
+        assert.deepStrictEqual(M.parseMenuJsonc("{ not json"), []);
+        assert.deepStrictEqual(M.parseMenuJsonc(""), []);
+        assert.deepStrictEqual(M.parseMenuJsonc(null), []);
+    });
+});
+
+describe("mergeMenuSources", () => {
+    test("the user file overrides a default entry by id", () => {
+        const { items } = merged();
+        assert.strictEqual(items["style.theme"].label, "Colour theme");
+        assert.strictEqual(items["style.theme"].action, "my-theme-switcher");
+    });
+
+    test("keeps entries only the user defines", () => {
+        assert.strictEqual(merged().items["custom.note"].label, "Note");
+    });
+
+    test("an overridden id is not duplicated in the order", () => {
+        const { itemOrder } = merged();
+        assert.strictEqual(itemOrder.filter(id => id === "style.theme").length, 1);
+    });
+
+    // Regression: order used to be stamped onto the caller's objects. Those live
+    // in QML `var` properties, where an in-place write can be dropped, which
+    // would collapse searchScore's declaration-order tiebreak.
+    test("does not mutate the arrays it is given", () => {
+        const d = defaultItems();
+        const before = d.map(e => e.order);
+        M.mergeMenuSources(d, []);
+        assert.deepStrictEqual(d.map(e => e.order), before);
+    });
+
+    // Worth pinning down because it surprises people writing an override: every
+    // field is normalised, so a partial override blanks the ones it omits. Same
+    // behaviour as Omarchy's own MenuModel.js.
+    test("a partial override blanks the fields it does not declare", () => {
+        const { items } = merged();
+        const fromDefault = defaultItems().find(e => e.id === "style.theme");
+        assert.strictEqual(fromDefault.description, "change the colour scheme");
+        assert.strictEqual(items["style.theme"].description, "",
+            "the user entry omits description, so the merged entry loses it");
+    });
+
+    test("skips entries without an id", () => {
+        const { itemOrder } = M.mergeMenuSources([null, { label: "x" }], []);
+        assert.deepStrictEqual(itemOrder, []);
+    });
+});
+
+describe("matchesQuery", () => {
+    const find = id => merged().items[id];
+
+    test("matches on the label", () => {
+        assert.ok(M.matchesQuery(find("system.lock"), "lock"));
+    });
+
+    test("matches on an alias", () => {
+        assert.ok(M.matchesQuery(find("install.docker"), "container runtime"));
+    });
+
+    test("matches a whole word of the description", () => {
+        // setup.dns is not overridden, so it keeps its description. Its label is
+        // "DNS", so "resolver" can only be matching the description.
+        assert.ok(M.matchesQuery(find("setup.dns"), "resolver"));
+    });
+
+    // A bare substring of the description must not match, or "in" would drag in
+    // everything that says "install".
+    test("does not match a partial word of the description", () => {
+        assert.ok(!M.matchesQuery(find("setup.dns"), "esolver"));
+    });
+
+    test("requires every term to match", () => {
+        assert.ok(!M.matchesQuery(find("system.lock"), "lock nonsense"));
+    });
+
+    test("never matches the synthetic root", () => {
+        assert.ok(!M.matchesQuery({ id: "root", label: "root" }, "root"));
+    });
+});
+
+describe("searchScore", () => {
+    const { items } = merged();
+    const score = id => M.searchScore(items, items[id], "theme");
+
+    test("an exact label beats a partial one", () => {
+        const exact = M.searchScore(items, items["system.lock"], "lock");
+        const partial = M.searchScore(items, items["style.theme"], "theme");
+        assert.ok(exact < partial, `exact ${exact} should sort before partial ${partial}`);
+    });
+
+    test("a prefix match beats a description-only match", () => {
+        const prefix = M.searchScore(items, items["install.docker"], "dock");
+        const desc = M.searchScore(items, items["setup.dns"], "resolver");
+        assert.ok(prefix < desc, `prefix ${prefix} should sort before description ${desc}`);
+    });
+
+    test("is stable for the same input", () => {
+        assert.strictEqual(score("style.theme"), score("style.theme"));
+    });
+});
+
+describe("pathFor / parentPathFor", () => {
+    const { items } = merged();
+
+    test("builds a breadcrumb from the ancestors", () => {
+        assert.strictEqual(M.pathFor(items, "system.lock"), "System › Lock");
+        assert.strictEqual(M.parentPathFor(items, "system.lock"), "System");
+    });
+
+    test("a top-level entry has no parent path", () => {
+        assert.strictEqual(M.parentPathFor(items, "system"), "");
+    });
+});
+
+describe("shellQuote", () => {
+    test("wraps a plain value", () => {
+        assert.strictEqual(M.shellQuote("plain"), "'plain'");
+    });
+
+    test("neutralises a glob so bash cannot expand it", () => {
+        assert.strictEqual(M.shellQuote("opt*"), "'opt*'");
+    });
+
+    test("escapes an embedded single quote", () => {
+        assert.strictEqual(M.shellQuote("it's"), "'it'\\''s'");
+    });
+
+    test("treats null and undefined as empty", () => {
+        assert.strictEqual(M.shellQuote(null), "''");
+        assert.strictEqual(M.shellQuote(undefined), "''");
+    });
+});
+
+describe("guardScript", () => {
+    const scriptFor = extra => {
+        const { items } = merged();
+        Object.assign(items, extra || {});
+        return M.guardScript(items);
+    };
+
+    test("emits one branch per guarded entry and none for the rest", () => {
+        const script = scriptFor();
+        assert.match(script, /system\.suspend:w:1/);
+        assert.match(script, /system\.hibernate:w:1/);
+        // system.lock has no `when`, so it must not be probed at all.
+        assert.doesNotMatch(script, /system\.lock:w/);
+    });
+
+    test("uses printf with a quoted payload rather than echo", () => {
+        const script = scriptFor();
+        assert.match(script, /printf '%s\\n' '/);
+        assert.doesNotMatch(script, /then echo [^']/);
+    });
+
+    // An unquoted echo would expand this against the working directory, emitting
+    // one line per matching file and desynchronising the whole batch.
+    test("quotes an id containing a glob character", () => {
+        const script = scriptFor({ "opt*": { id: "opt*", when: "true" } });
+        assert.ok(script.includes("'opt*:w:1'"), "glob id should be quoted verbatim");
+    });
+
+    // The reply is split on the last two colons, so such an id could not be read
+    // back. Skipping it leaves one row unanswered instead of corrupting the rest.
+    test("skips ids that would break the reply format", () => {
+        const script = scriptFor({
+            "bad:id": { id: "bad:id", when: "true" },
+            "bad\nid": { id: "bad\nid", when: "true" }
+        });
+        assert.doesNotMatch(script, /bad:id/);
+        assert.doesNotMatch(script, /bad\nid/);
+    });
+
+    test("returns an empty string when nothing is guarded", () => {
+        assert.strictEqual(M.guardScript({ a: { id: "a", label: "A" } }), "");
+        assert.strictEqual(M.guardScript(null), "");
+    });
+});
+
+describe("guardScript + parseGuardReply round trip", () => {
+    test("a real bash run resolves each guard to its condition", () => {
+        const { items } = merged();
+        const out = execFileSync("bash", ["-c", M.guardScript(items)], { encoding: "utf8" });
+        const results = M.parseGuardReply(out);
+        assert.strictEqual(results["system.suspend"], true, "`when: true` should pass");
+        assert.strictEqual(results["system.hibernate"], false, "`when: false` should fail");
+        assert.ok(!("system.lock" in results), "an unguarded entry gets no answer");
+    });
+
+    test("a glob id survives the round trip intact", () => {
+        const items = { "opt*": { id: "opt*", when: "true" } };
+        const out = execFileSync("bash", ["-c", M.guardScript(items)], { encoding: "utf8" });
+        assert.deepStrictEqual(M.parseGuardReply(out), { "opt*": true });
+    });
+});
+
+describe("parseGuardReply", () => {
+    test("splits from the right so dotted ids survive", () => {
+        assert.deepStrictEqual(
+            M.parseGuardReply("a.b.c:w:1\nd.e:w:0\n"),
+            { "a.b.c": true, "d.e": false });
+    });
+
+    test("ignores the checked tag", () => {
+        assert.deepStrictEqual(M.parseGuardReply("a:c:1\nb:w:1\n"), { b: true });
+    });
+
+    test("skips blank and malformed lines", () => {
+        assert.deepStrictEqual(M.parseGuardReply("\n\nnocolons\na:w:1\n  \n"), { a: true });
+    });
+
+    test("treats anything but 1 as false", () => {
+        assert.deepStrictEqual(M.parseGuardReply("a:w:0\nb:w:\nc:w:x\n"),
+            { a: false, b: false, c: false });
+    });
+
+    test("returns an empty object for empty input", () => {
+        assert.deepStrictEqual(M.parseGuardReply(""), {});
+        assert.deepStrictEqual(M.parseGuardReply(null), {});
+    });
+});


### PR DESCRIPTION
Hi — thanks for the plugin, it has become my daily driver. This adds search
inside the overview, scopes the workspace preview per monitor, and fixes a few
things I ran into while using it. Happy to split it into separate PRs if you
would rather review them independently.

## Search inside the overview

Typing any printable character while the overview is open enters search mode,
with the query shown in a bar above the workspace cards. Enter activates, arrows
and Tab move the selection, Escape leaves. Results combine, in order: a `>`
shell command, applications, open windows, and executable rows from the Omarchy
command menu.

Most of the machinery was already in the repo but switched off: the keyboard
handling sat commented out in `Overview.qml` under `DISABLED: search UI
removed`, and `AppSearch.fuzzyQuery` returned an empty list, so the Applications
section could never appear. Both are restored. Application results come from
`DesktopEntries` and launch via `uwsm-app -- gtk-launch`, and the same
`launcher.hides` list Omarchy's own launcher uses is applied, so results agree
with the Super+Space menu.

**Trade-off worth flagging:** `h`/`j`/`k`/`l` no longer navigate workspaces,
since any letter now starts a search. The arrow keys still do. I suspect this is
why the search was disabled in the first place — if you would prefer search to
start on an explicit key such as `/`, that is a small change and I am glad to
make it.

### Menu indexing

`MenuIndex.js` is written in-repo rather than importing Omarchy's
`MenuModel.js`. QML resolves JS imports statically while Omarchy's prefix comes
from `$OMARCHY_PATH`, which is not `/usr/share/omarchy` on NixOS — a fixed path
would fail to load the whole plugin instead of degrading one feature, which
seemed worth avoiding given `docs/nixos-reload-and-thumbnails.md`. It was
verified to return results identical to `MenuModel.js` across fifteen queries.

144 of the menu's 263 actions carry a `when:` guard, so an unevaluated index
would offer actions that do not apply — Hibernate on a machine that cannot
hibernate. `guardScript()` resolves them in one batched bash run. Unlike
Omarchy it emits no pacman-caching prelude: the helpers it depends on exist as
real binaries in `$OMARCHY_PATH/bin`, so the expressions run either way.
Measured at 2.87s against 2.22s for the optimised batch, with identical results
for all 144 guards; it runs in the background and answers are cached.

## Per-monitor workspace preview

Every overlay drew the full grid, so each screen showed the other monitor's
workspaces alongside its own. `OverviewWidget` already derived a
`localMonitorGroup` but used it only to pick the highlighted card.

Scoping happens at the source: `overviewEntries` asks
`overviewWorkspaceEntriesForMonitor()` for its own screen, so `monitorGroups`
collapses to a single group and the grid, height and aspect maths are untouched.
`WorkspaceNavigation.overviewModel()` is scoped to the anchor monitor too,
otherwise the arrow keys walk the selection onto cards the overlay does not draw.

Exposed as an ON/OFF row in the gear panel, persisted to the bar widget entry in
`shell.json` like `sortMode`, and only rendered when more than one monitor is
connected.

## Fixes

**Key bindings did not survive a Hyprland config reload.** They live only in
Hyprland's runtime, so a theme change, `omarchy refresh`, editing a `.lua` file
or a monitor hotplug dropped all 144 of them, and Super silently fell back to
Omarchy's own menu until the shell was restarted by hand. `KeybindingService`
now listens for `configreloaded`. Verified by removing and restoring the
handler: without it a reload takes the bindings to 0 and `SUPER_L` reverts to
"Omarchy menu (tap SUPER)"; with it they stay at 144, and the interrupt guards
stay at 63 rather than doubling.

**Clicking a window often left the previous one focused.** The click dismissed
the overview before dispatching focus, and closing the layer surface hands focus
back to whatever was active — a race the dismissal usually won on a short click
and lost on a long one. Dispatch now precedes the dismissal, in all three paths.
`OverviewSearch.focusWindow()` already used this order, which is why activating
a search result never showed the problem.

**A guard re-evaluation queued during a running batch was dropped**, leaving
`whenResults` describing the previous item set. `whenResults` is deliberately
not cleared when a batch fails: with no answers every guarded action passes,
which is the opposite of what guards are for.

## Testing

Verified on Omarchy 4.0.2 / Hyprland 0.56.2 with two monitors. The shell loads
without QML warnings, guard evaluation returns 77 visible and 67 hidden of the
144 guards, and menu queries match `MenuModel.js`.

Not exercised: three or more monitors, and NixOS (the `$OMARCHY_PATH` reasoning
above is from reading Omarchy's source, not from running there).
